### PR TITLE
Update dailyheathcliff.js

### DIFF
--- a/heathcliff-bot/commands/utility/dailyheathcliff.js
+++ b/heathcliff-bot/commands/utility/dailyheathcliff.js
@@ -5,14 +5,14 @@ module.exports = {
 		.setName("dailyheathcliff")
 		.setDescription("posts Heathclilff comic for today's date"),
 	async execute(interaction) {
-		var today = new Date();
-		var dd = String(today.getDate()).padStart(2, '0');
-		var mm = String(today.getMonth() + 1).padStart(2, '0'); //January is 0!
-		var yyyy = today.getFullYear();
+		//var today = new Date();
+		//var dd = String(today.getDate()).padStart(2, '0');
+		//var mm = String(today.getMonth() + 1).padStart(2, '0'); //January is 0!
+		//var yyyy = today.getFullYear();
 
-		today = yyyy + '/' + mm + '/' + dd;
-
-		var url = String('https://www.gocomics.com/heathcliff/' + yyyy + '/' + mm + '/' + dd);
+		//today = yyyy + '/' + mm + '/' + dd;
+// GOCOMICS Broke Heathcliff bot, this should fix daily heathcliffs for the moment, until I work out how the silly little creators thing looks up the right comic.
+		var url = String('https://www.creators.com/read/heathcliff);
 
 		try {
 			await interaction.reply(url);


### PR DESCRIPTION
Gocomics broke Heathcliff bot, this URL change will fix just the Daily comic posts, which is my most used feature :)

Idk how Creators dot com does their numbering, it appears to go,

MM/YY/IMAGEID (?) but it clearly has to be tied to a date somewhere, so I will look into that